### PR TITLE
This change prevents jsmockito from contstructing instances of the classes you mock, which prevents us from being able to use it.

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -44,8 +44,11 @@
 JsMockito.mock = function(Obj, delegate) {
   delegate = delegate || {};
 
+  var IntermediateObj = function() { };
+  IntermediateObj.prototype = Obj.prototype;
+
   var MockObject = function() { };
-  MockObject.prototype = (typeof Obj == "function")? new Obj : Obj;
+  MockObject.prototype = (typeof Obj == "function")? new IntermediateObj : Obj;
   MockObject.prototype.constructor = MockObject;
 
   var mockObject = new MockObject();


### PR DESCRIPTION
Allow objects to be mocked without having to construct an instance of them.
