### PR TITLE
Corrected Syntax - missing parenthesis

### DIFF
--- a/src/jsmockito.js
+++ b/src/jsmockito.js
@@ -108,7 +108,7 @@
  * } catch (e) {
  *   ex = e;
  * }
- * assertThat(ex, equalTo('An exception');
+ * assertThat(ex, equalTo('An exception'));
  *
  * //the following invokes the stub method, which returns 3
  * assertThat(mockedArray.slice(2), equalTo(3));
@@ -162,7 +162,7 @@
  * } catch (e) {
  *   ex = e;
  * }
- * assertThat(ex, equalTo('An exception');
+ * assertThat(ex, equalTo('An exception'));
  *
  * //the following invokes the stub method, which returns 3
  * assertThat(mockedFunc(2), equalTo(3));


### PR DESCRIPTION
https://xkcd.com/859/

The documentation contains a syntax error.  This corrects it.  I have not proven that other errors don't exist, I have only fixed the one I spotted.
